### PR TITLE
Uninstall scheduler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,14 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/org.springframework/spring-beans -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>2.5.6.SEC03</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- WIRED TEST RUNNER DEPENDENCIES -->
     <dependency>
       <groupId>com.atlassian.plugins</groupId>

--- a/src/main/java/com/blackducksoftware/integration/jira/task/HubMonitor.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/task/HubMonitor.java
@@ -51,6 +51,7 @@ public class HubMonitor implements NotificationMonitor, LifecycleAware {
 	/* package */static final String KEY_INSTANCE = HubMonitor.class.getName() + ":instance";
 	public static final String KEY_SETTINGS = HubMonitor.class.getName() + ":settings";
 	private static final String JOB_NAME = HubMonitor.class.getName() + ":job";
+	public static final String PREVIOUS_INTERVAL = HubMonitor.class.getName() + ":previousInterval";
 
 	private final HubJiraLogger logger = new HubJiraLogger(Logger.getLogger(this.getClass().getName()));
 

--- a/src/main/java/com/blackducksoftware/integration/jira/task/JiraTask.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/task/JiraTask.java
@@ -51,8 +51,6 @@ public class JiraTask implements PluginJob {
 	public void execute(final Map<String, Object> jobDataMap) {
 
 		final PluginSettings settings = (PluginSettings) jobDataMap.get(HubMonitor.KEY_SETTINGS);
-		final HubMonitor hubMonitor = (HubMonitor) jobDataMap.get(HubMonitor.KEY_INSTANCE);
-		final String oldIntervalString = (String) jobDataMap.get(HubMonitor.PREVIOUS_INTERVAL);
 		final String hubUrl = getStringValue(settings, HubConfigKeys.CONFIG_HUB_URL);
 		final String hubUsername = getStringValue(settings, HubConfigKeys.CONFIG_HUB_USER);
 		final String hubPasswordEncrypted = getStringValue(settings, HubConfigKeys.CONFIG_HUB_PASS);
@@ -77,8 +75,6 @@ public class JiraTask implements PluginJob {
 		final String jiraUser = getStringValue(settings, HubJiraConfigKeys.HUB_CONFIG_JIRA_USER);
 
 		final JiraSettingsService jiraSettingsService = new JiraSettingsService(settings);
-
-		logger.debug("HubMonitor name: " + hubMonitor.getName());
 
 		if (hubUrl == null || hubUsername == null || hubPasswordEncrypted == null) {
 			logger.warn("The Hub connection details have not been configured, therefore there is nothing to do.");
@@ -113,31 +109,6 @@ public class JiraTask implements PluginJob {
 		final String runDateString = processor.execute();
 		if (runDateString != null) {
 			settings.put(HubJiraConfigKeys.HUB_CONFIG_LAST_RUN_DATE, runDateString);
-		}
-
-		// TODO factor this out to a method
-		logger.debug("Comparing intervalString (" + intervalString + ") to oldIntervalString (" + oldIntervalString
-				+ ")");
-		boolean changeInterval = false;
-		if (lastRunDateString == null) {
-			logger.debug("There is no last run date; this must be the first run");
-		} else if (oldIntervalString == null) {
-			// oldIntervalString gets wiped out when config is saved
-			logger.info("Config was saved. Will reschedule this task in case interval changed");
-			changeInterval = true;
-		} else if (oldIntervalString.equals(intervalString)) {
-			logger.debug("The interval has not changed");
-		} else {
-			logger.info("Interval has changed. Need to reschedule this task");
-			changeInterval = true;
-		}
-		jobDataMap.put(HubMonitor.PREVIOUS_INTERVAL, intervalString);
-
-		if (changeInterval) {
-			// TODO: calling changeInterval results in an infinite loop
-			// because oldIntervalString is null when it gets back into this
-			// method
-			// hubMonitor.changeInterval();
 		}
 	}
 

--- a/src/main/java/com/blackducksoftware/integration/jira/task/JiraTask.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/task/JiraTask.java
@@ -51,6 +51,8 @@ public class JiraTask implements PluginJob {
 	public void execute(final Map<String, Object> jobDataMap) {
 
 		final PluginSettings settings = (PluginSettings) jobDataMap.get(HubMonitor.KEY_SETTINGS);
+		final HubMonitor hubMonitor = (HubMonitor) jobDataMap.get(HubMonitor.KEY_INSTANCE);
+		final String oldIntervalString = (String) jobDataMap.get(HubMonitor.PREVIOUS_INTERVAL);
 		final String hubUrl = getStringValue(settings, HubConfigKeys.CONFIG_HUB_URL);
 		final String hubUsername = getStringValue(settings, HubConfigKeys.CONFIG_HUB_USER);
 		final String hubPasswordEncrypted = getStringValue(settings, HubConfigKeys.CONFIG_HUB_PASS);
@@ -75,6 +77,8 @@ public class JiraTask implements PluginJob {
 		final String jiraUser = getStringValue(settings, HubJiraConfigKeys.HUB_CONFIG_JIRA_USER);
 
 		final JiraSettingsService jiraSettingsService = new JiraSettingsService(settings);
+
+		logger.debug("HubMonitor name: " + hubMonitor.getName());
 
 		if (hubUrl == null || hubUsername == null || hubPasswordEncrypted == null) {
 			logger.warn("The Hub connection details have not been configured, therefore there is nothing to do.");
@@ -109,6 +113,31 @@ public class JiraTask implements PluginJob {
 		final String runDateString = processor.execute();
 		if (runDateString != null) {
 			settings.put(HubJiraConfigKeys.HUB_CONFIG_LAST_RUN_DATE, runDateString);
+		}
+
+		// TODO factor this out to a method
+		logger.debug("Comparing intervalString (" + intervalString + ") to oldIntervalString (" + oldIntervalString
+				+ ")");
+		boolean changeInterval = false;
+		if (lastRunDateString == null) {
+			logger.debug("There is no last run date; this must be the first run");
+		} else if (oldIntervalString == null) {
+			// oldIntervalString gets wiped out when config is saved
+			logger.info("Config was saved. Will reschedule this task in case interval changed");
+			changeInterval = true;
+		} else if (oldIntervalString.equals(intervalString)) {
+			logger.debug("The interval has not changed");
+		} else {
+			logger.info("Interval has changed. Need to reschedule this task");
+			changeInterval = true;
+		}
+		jobDataMap.put(HubMonitor.PREVIOUS_INTERVAL, intervalString);
+
+		if (changeInterval) {
+			// TODO: calling changeInterval results in an infinite loop
+			// because oldIntervalString is null when it gets back into this
+			// method
+			// hubMonitor.changeInterval();
 		}
 	}
 


### PR DESCRIPTION
@jrichardBD This has the changes to: 1. Remove the old v1 scheduler, and the current scheduler, if either are found before installing the current scheduler, and 2. Remove the scheduler on uninstall.
