### PR TITLE
Bm close issues button

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/jira/common/exception/JiraException.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/common/exception/JiraException.java
@@ -26,7 +26,7 @@ package com.blackducksoftware.integration.jira.common.exception;
 public class JiraException extends Exception {
     private static final long serialVersionUID = -8266124446156847454L;
 
-    // This value displays in the UI as the type of error
+    // This value stores the name of the method that was called and resulted in error.
     private String methodAttempt = "unknown";
 
     public JiraException() {

--- a/src/main/java/com/blackducksoftware/integration/jira/common/exception/JiraException.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/common/exception/JiraException.java
@@ -26,6 +26,7 @@ package com.blackducksoftware.integration.jira.common.exception;
 public class JiraException extends Exception {
     private static final long serialVersionUID = -8266124446156847454L;
 
+    // This value displays in the UI as the type of error
     private String methodAttempt = "unknown";
 
     public JiraException() {

--- a/src/main/java/com/blackducksoftware/integration/jira/common/exception/JiraIssueException.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/common/exception/JiraIssueException.java
@@ -31,6 +31,7 @@ public class JiraIssueException extends JiraException {
 
     private ErrorCollection errorCollection = ErrorCollections.empty();
 
+    // FIXME make the constructor methodAttempt param in the same place for both constructors.
     public JiraIssueException(final String message, final String methodAttempt) {
         super(message);
         super.setMethodAttempt(methodAttempt);

--- a/src/main/java/com/blackducksoftware/integration/jira/config/controller/ManagementController.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/config/controller/ManagementController.java
@@ -1,0 +1,77 @@
+/**
+ * Black Duck JIRA Plugin
+ *
+ * Copyright (C) 2019 Synopsys, Inc.
+ * https://www.synopsys.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.jira.config.controller;
+
+import static javax.ws.rs.core.Response.Status;
+import static javax.ws.rs.core.Response.noContent;
+import static javax.ws.rs.core.Response.serverError;
+import static javax.ws.rs.core.Response.status;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.sal.api.transaction.TransactionTemplate;
+import com.atlassian.sal.api.user.UserKey;
+import com.atlassian.sal.api.user.UserManager;
+import com.blackducksoftware.integration.jira.common.exception.JiraIssueException;
+import com.blackducksoftware.integration.jira.config.JiraServices;
+import com.blackducksoftware.integration.jira.config.controller.action.ManageOldIssues;
+
+@Path("/config/management")
+public class ManagementController extends ConfigController {
+    private final ManageOldIssues manageOldIssues;
+
+    public ManagementController(final PluginSettingsFactory pluginSettingsFactory, final TransactionTemplate transactionTemplate, final UserManager userManager, final com.atlassian.jira.user.util.UserManager jiraUserManager) {
+        super(pluginSettingsFactory, transactionTemplate, userManager);
+        this.manageOldIssues = new ManageOldIssues(new JiraServices(), jiraUserManager);
+    }
+
+    @PUT
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Response put(final String oldUrl, @Context final HttpServletRequest request) {
+        final boolean validAuthentication = isAuthorized(request);
+        if (!validAuthentication) {
+            return status(Status.UNAUTHORIZED).build();
+        }
+
+        try {
+            final Optional<UserKey> userKey = getAuthorizationChecker().getUserKey(request);
+            if (userKey.isPresent()) {
+                manageOldIssues.closeAllIssues(userKey.get(), oldUrl);
+            }
+        } catch (final JiraIssueException e) {
+            return serverError().build();
+        }
+
+        return noContent().build();
+    }
+}

--- a/src/main/java/com/blackducksoftware/integration/jira/config/controller/ManagementController.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/config/controller/ManagementController.java
@@ -28,6 +28,8 @@ import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.serverError;
 import static javax.ws.rs.core.Response.status;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
@@ -73,13 +75,13 @@ public class ManagementController extends ConfigController {
             if (userKey.isPresent()) {
                 final Gson gson = new GsonBuilder().create();
                 final JsonObject jsonObject = gson.fromJson(oldUrl, JsonObject.class);
-                final String url = jsonObject.get("oldUrl").getAsString();
+                final String url = new URL(jsonObject.get("oldUrl").getAsString()).toString();
                 if (StringUtils.isBlank(url)) {
                     return Response.status(Status.BAD_REQUEST).build();
                 }
                 manageOldIssues.closeAllIssues(userKey.get(), url);
             }
-        } catch (final JiraIssueException e) {
+        } catch (final JiraIssueException | MalformedURLException e) {
             return serverError().build();
         }
 

--- a/src/main/java/com/blackducksoftware/integration/jira/config/controller/action/ManageOldIssues.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/config/controller/action/ManageOldIssues.java
@@ -91,14 +91,14 @@ public class ManageOldIssues {
 
     private List<Issue> retrievePagedOldIssues(final ApplicationUser adminUser, final int startingOffset, final int resultLimit) throws JiraIssueException {
         final PagerFilter queryPageLimiter = PagerFilter.newPageAlignedFilter(startingOffset, resultLimit);
-        final Query jqlQuery = createIssueQuery().orElseThrow(() -> new JiraIssueException("The generated Issues search query was invalid.", "queryForIssues"));
+        final Query jqlQuery = createIssueQuery().orElseThrow(() -> new JiraIssueException("The generated Issues search query was invalid.", "retrievePagedOldIssues"));
 
         try {
             final SearchService jiraSearchService = jiraServices.getSearchService();
             final SearchResults searchResults = jiraSearchService.search(adminUser, jqlQuery, queryPageLimiter);
             return searchResults.getIssues();
         } catch (final SearchException e) {
-            throw new JiraIssueException("Error executing query: " + jqlQuery.getQueryString() + " | Error Message: " + e.getMessage(), "queryForIssues");
+            throw new JiraIssueException("Error executing query: " + jqlQuery.getQueryString() + " | Error Message: " + e.getMessage(), "retrievePagedOldIssues");
         }
     }
 
@@ -180,7 +180,7 @@ public class ManageOldIssues {
                 return descriptor.getId();
             }
         }
-        throw new JiraIssueException("Was unable to find the expected transition for workflow.", "retrieveTransition");
+        throw new JiraIssueException("Unable to find the expected transition for workflow.", "getTransitionId");
     }
 
     public Map<String, String> getIssueProperties(final Long issueId, final ApplicationUser user) {

--- a/src/main/java/com/blackducksoftware/integration/jira/config/controller/action/ManageOldIssues.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/config/controller/action/ManageOldIssues.java
@@ -1,0 +1,190 @@
+/**
+ * Black Duck JIRA Plugin
+ *
+ * Copyright (C) 2019 Synopsys, Inc.
+ * https://www.synopsys.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.jira.config.controller.action;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.log4j.Logger;
+
+import com.atlassian.jira.bc.issue.IssueService;
+import com.atlassian.jira.bc.issue.properties.IssuePropertyService;
+import com.atlassian.jira.bc.issue.search.SearchService;
+import com.atlassian.jira.entity.property.EntityProperty;
+import com.atlassian.jira.issue.Issue;
+import com.atlassian.jira.issue.IssueInputParameters;
+import com.atlassian.jira.issue.search.SearchException;
+import com.atlassian.jira.issue.search.SearchResults;
+import com.atlassian.jira.jql.parser.DefaultJqlQueryParser;
+import com.atlassian.jira.jql.parser.JqlParseException;
+import com.atlassian.jira.jql.parser.JqlQueryParser;
+import com.atlassian.jira.user.ApplicationUser;
+import com.atlassian.jira.user.util.UserManager;
+import com.atlassian.jira.util.ErrorCollection;
+import com.atlassian.jira.web.bean.PagerFilter;
+import com.atlassian.jira.workflow.JiraWorkflow;
+import com.atlassian.jira.workflow.WorkflowManager;
+import com.atlassian.query.Query;
+import com.atlassian.sal.api.user.UserKey;
+import com.blackducksoftware.integration.jira.common.BlackDuckJiraConstants;
+import com.blackducksoftware.integration.jira.common.BlackDuckJiraLogger;
+import com.blackducksoftware.integration.jira.common.exception.JiraIssueException;
+import com.blackducksoftware.integration.jira.config.JiraServices;
+import com.opensymphony.workflow.loader.ActionDescriptor;
+
+public class ManageOldIssues {
+    private static final String JIRA_QUERY_PARAM_NAME_ISSUE_STATUS = "status";
+    private static final String JIRA_QUERY_PARAM_NAME_ISSUE_TYPE = "issuetype";
+    private static final String JIRA_QUERY_CONJUNCTION = " AND ";
+    private static final String JIRA_QUERY_DISJUNCTION = " OR ";
+    private final BlackDuckJiraLogger logger = new BlackDuckJiraLogger(Logger.getLogger(this.getClass().getName()));
+    private final JiraServices jiraServices;
+    private final UserManager userManager;
+
+    public ManageOldIssues(final JiraServices jiraServices, final UserManager userManager) {
+        this.jiraServices = jiraServices;
+        this.userManager = userManager;
+    }
+
+    public void closeAllIssues(final UserKey userKey, final String oldUrl) throws JiraIssueException {
+        int offset = 0;
+        final int resultLimit = 1000;
+
+        final ApplicationUser adminUser = userManager.getUserByKey(userKey.getStringValue());
+        List<Issue> issues = retrievePagedOldIssues(adminUser, offset, resultLimit);
+
+        while (issues.size() >= resultLimit) {
+            for (final Issue issue : issues) {
+                if (shouldIssueBeTransitioned(issue.getId(), adminUser, oldUrl)) {
+                    transitionIssue(issue);
+                }
+            }
+
+            offset += resultLimit;
+            issues = retrievePagedOldIssues(adminUser, offset, resultLimit);
+        }
+    }
+
+    private List<Issue> retrievePagedOldIssues(final ApplicationUser adminUser, final int startingOffset, final int resultLimit) throws JiraIssueException {
+        final PagerFilter queryPageLimiter = PagerFilter.newPageAlignedFilter(startingOffset, resultLimit);
+        final Query jqlQuery = createIssueQuery().orElseThrow(() -> new JiraIssueException("The generated Issues search query was invalid.", "queryForIssues"));
+
+        try {
+            final SearchService jiraSearchService = jiraServices.getSearchService();
+            final SearchResults searchResults = jiraSearchService.search(adminUser, jqlQuery, queryPageLimiter);
+            return searchResults.getIssues();
+        } catch (final SearchException e) {
+            throw new JiraIssueException("Error executing query: " + jqlQuery.getQueryString() + " | Error Message: " + e.getMessage(), "queryForIssues");
+        }
+    }
+
+    private Optional<Query> createIssueQuery() {
+        final StringBuilder queryBuilder = new StringBuilder();
+        appendEqualityCheck(queryBuilder, JIRA_QUERY_PARAM_NAME_ISSUE_TYPE, BlackDuckJiraConstants.BLACKDUCK_POLICY_VIOLATION_ISSUE);
+        queryBuilder.append(JIRA_QUERY_DISJUNCTION);
+        appendEqualityCheck(queryBuilder, JIRA_QUERY_PARAM_NAME_ISSUE_TYPE, BlackDuckJiraConstants.BLACKDUCK_SECURITY_POLICY_VIOLATION_ISSUE);
+        queryBuilder.append(JIRA_QUERY_DISJUNCTION);
+        appendEqualityCheck(queryBuilder, JIRA_QUERY_PARAM_NAME_ISSUE_TYPE, BlackDuckJiraConstants.BLACKDUCK_VULNERABILITY_ISSUE);
+        queryBuilder.append(JIRA_QUERY_CONJUNCTION);
+        appendEqualityCheck(queryBuilder, JIRA_QUERY_PARAM_NAME_ISSUE_STATUS, "Open");
+        // Query from least recently updated to most
+        queryBuilder.append(" ORDER BY updated ASC");
+
+        final String queryString = queryBuilder.toString();
+        try {
+            final JqlQueryParser queryParser = new DefaultJqlQueryParser();
+            final Query orphanQuery = queryParser.parseQuery(queryString);
+            return Optional.of(orphanQuery);
+        } catch (final JqlParseException e) {
+            logger.warn("The query generated to search for orphan issues was invalid: " + queryString);
+        }
+        return Optional.empty();
+    }
+
+    private void appendEqualityCheck(final StringBuilder queryBuilder, final String key, final String value) {
+        queryBuilder.append(createComparisonCheck(key, value, "="));
+    }
+
+    private void appendContainsCheck(final StringBuilder queryBuilder, final String key, final String value) {
+        queryBuilder.append(createComparisonCheck(key, value, "~"));
+    }
+
+    private String createComparisonCheck(final String key, final String value, final String comparison) {
+        final StringBuilder queryBuilder = new StringBuilder();
+
+        queryBuilder.append(key);
+        queryBuilder.append(" ");
+        queryBuilder.append(comparison);
+        queryBuilder.append(" \"");
+        queryBuilder.append(value);
+        queryBuilder.append("\"");
+
+        return queryBuilder.toString();
+    }
+
+    private boolean shouldIssueBeTransitioned(final Long issueId, final ApplicationUser user, final String oldUrl) {
+        return getIssueProperties(issueId, user)
+                   .keySet()
+                   .stream()
+                   .anyMatch(key -> key.contains(oldUrl));
+    }
+
+    private void transitionIssue(final Issue issue) throws JiraIssueException {
+        final IssueService issueService = jiraServices.getIssueService();
+        final IssueInputParameters issueInputParameters = issueService.newIssueInputParameters();
+        issueInputParameters.setRetainExistingValuesWhenParameterNotProvided(true);
+
+        final IssueService.TransitionValidationResult validationResult = issueService.validateTransition(issue.getCreator(), issue.getId(), getTransitionId(issue), issueInputParameters);
+        if (validationResult.isValid()) {
+            final IssueService.IssueResult result = issueService.transition(issue.getCreator(), validationResult);
+            final ErrorCollection errors = result.getErrorCollection();
+            if (errors.hasAnyErrors()) {
+                throw new JiraIssueException("transitionIssue", errors);
+            }
+        }
+        throw new JiraIssueException("transitionIssue", validationResult.getErrorCollection());
+    }
+
+    private int getTransitionId(final Issue issue) throws JiraIssueException {
+        final WorkflowManager workflowManager = jiraServices.getWorkflowManager();
+        final JiraWorkflow workflow = workflowManager.getWorkflow(issue);
+        final List<ActionDescriptor> actions = workflow.getLinkedStep(issue.getStatus()).getActions();
+
+        for (final ActionDescriptor descriptor : actions) {
+            if (descriptor.getName() != null && descriptor.getName().equals(BlackDuckJiraConstants.BLACKDUCK_WORKFLOW_TRANSITION_REMOVE_OR_OVERRIDE)) {
+                return descriptor.getId();
+            }
+        }
+        throw new JiraIssueException("Was unable to find the expected transition for workflow.", "retrieveTransition");
+    }
+
+    public Map<String, String> getIssueProperties(final Long issueId, final ApplicationUser user) {
+        final IssuePropertyService issuePropertyService = jiraServices.getPropertyService();
+        return issuePropertyService.getProperties(user, issueId)
+                   .stream()
+                   .collect(Collectors.toMap(EntityProperty::getKey, EntityProperty::getValue));
+    }
+}

--- a/src/main/java/com/blackducksoftware/integration/jira/task/maintenance/CleanUpOrphanedTicketsTask.java
+++ b/src/main/java/com/blackducksoftware/integration/jira/task/maintenance/CleanUpOrphanedTicketsTask.java
@@ -241,11 +241,13 @@ public class CleanUpOrphanedTicketsTask implements Callable<String> {
 
     private Optional<Query> createOrphanedTicketQuery() {
         final StringBuilder queryBuilder = new StringBuilder();
+        queryBuilder.append("(");
         appendEqualityCheck(queryBuilder, JIRA_QUERY_PARAM_NAME_ISSUE_TYPE, BlackDuckJiraConstants.BLACKDUCK_POLICY_VIOLATION_ISSUE);
         queryBuilder.append(JIRA_QUERY_DISJUNCTION);
         appendEqualityCheck(queryBuilder, JIRA_QUERY_PARAM_NAME_ISSUE_TYPE, BlackDuckJiraConstants.BLACKDUCK_SECURITY_POLICY_VIOLATION_ISSUE);
         queryBuilder.append(JIRA_QUERY_DISJUNCTION);
         appendEqualityCheck(queryBuilder, JIRA_QUERY_PARAM_NAME_ISSUE_TYPE, BlackDuckJiraConstants.BLACKDUCK_VULNERABILITY_ISSUE);
+        queryBuilder.append(") ");
         queryBuilder.append(JIRA_QUERY_CONJUNCTION);
         appendEqualityCheck(queryBuilder, JIRA_QUERY_PARAM_NAME_ISSUE_STATUS, "Open");
         // Query from least recently updated to most

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -104,6 +104,7 @@
         <resource type="download" name="images/" location="/images"/>
         <resource type="download" name="fonts/" location="/font-awesome-4.5.0/fonts"/>
         <resource type="download" name="font-awesome.min.css" location="/font-awesome-4.5.0/css/font-awesome.min.css"/>
+        <resource type="download" name="management-request.js" location="/js/management/management-request.js"/>
         <context>hub-jira</context>
     </web-resource>
 

--- a/src/main/resources/com/blackducksoftware/integration/jira/i18n_6.properties
+++ b/src/main/resources/com/blackducksoftware/integration/jira/i18n_6.properties
@@ -104,3 +104,8 @@ blackduck.integration.jira.server.details.proxy.host.description=The hostname of
 blackduck.integration.jira.server.details.proxy.port.description=The port of the Proxy to use, Integer
 blackduck.integration.jira.server.details.proxy.username.description=The Proxy username for authenticated Proxies
 blackduck.integration.jira.server.details.proxy.password.description=The Proxy password for authenticated Proxies
+# ManageMent Values:
+blackduck.integration.jira.management.label=Management
+blackduck.integration.jira.management.clean.old.issues.label=Old BlackDuck server URL
+blackduck.integration.jira.management.clean.old.issues.description=This button will remove any old issues in your Jira instance that are associated with the Black Duck URL you pass here. Must be a valid URL.
+blackduck.integration.jira.management.clean.old.issues.button=Close Old Issues

--- a/src/main/resources/js/management/management-request.js
+++ b/src/main/resources/js/management/management-request.js
@@ -1,3 +1,26 @@
+/*
+ * Black Duck JIRA Plugin
+ *
+ * Copyright (C) 2019 Synopsys, Inc.
+ * https://www.synopsys.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 function closeOldIssues() {
     var oldUrl = $("jiraCleanOldIssues").val();
     AJS.$.ajax({

--- a/src/main/resources/js/management/management-request.js
+++ b/src/main/resources/js/management/management-request.js
@@ -1,0 +1,40 @@
+function closeOldIssues() {
+    var oldUrl = $("jiraCleanOldIssues").val();
+    AJS.$.ajax({
+        url: createRequestPath('config/blackduck'),
+        dataType: "json",
+        success: function (config) {
+            console.log("Successful get of hub details for " + config.hubUrl);
+
+            updateValue("hubServerUrl", config.hubUrl);
+            updateValue("hubTimeout", config.timeout);
+            updateValue("hubTrustCert", config.trustCert);
+            updateValue("bdApiToken", config.apiToken);
+            updateValue("proxyHost", config.hubProxyHost);
+            updateValue("proxyPort", config.hubProxyPort);
+            updateValue("proxyUsername", config.hubProxyUser);
+            updateValue("proxyPassword", config.hubProxyPassword);
+
+            checkProxyConfig();
+
+            handleError(errorMessageFieldId, config.errorMessage, true, true);
+            handleErrorHubDetails('hubServerUrlErrorRow', 'hubServerUrlError', config.hubUrlError);
+            handleErrorHubDetails('hubTimeoutErrorRow', 'hubTimeoutError', config.timeoutError);
+            handleErrorHubDetails('hubTrustCertErrorRow', 'hubTrustCertError', config.trustCertError);
+            handleErrorHubDetails('bdApiTokenErrorRow', 'bdApiTokenError', config.apiTokenError);
+            handleErrorHubDetails('proxyHostErrorRow', 'proxyHostError', config.hubProxyHostError);
+            handleErrorHubDetails('proxyPortErrorRow', 'proxyPortError', config.hubProxyPortError);
+            handleErrorHubDetails('proxyUsernameErrorRow', 'proxyUsernameError', config.hubProxyUserError);
+            handleErrorHubDetails('proxyPasswordErrorRow', 'proxyPasswordError', config.hubProxyPasswordError);
+
+        }, error: function (response) {
+            console.log("putConfig(): " + response.responseText);
+            alert("There was an error loading the configuration.");
+            handleDataRetrievalError(response, 'configurationError', "There was a problem retrieving the configuration.", "Configuration Error");
+        },
+        complete: function (jqXHR, textStatus) {
+            stopProgressSpinner('hubDetailsProgressSpinner');
+            console.log("Completed get of hub details: " + textStatus);
+        }
+    });
+}

--- a/src/main/resources/js/management/management-request.js
+++ b/src/main/resources/js/management/management-request.js
@@ -22,41 +22,29 @@
  * under the License.
  */
 function closeOldIssues() {
-    var oldUrl = $("jiraCleanOldIssues").val();
+    startProgressSpinner('managementProgressSpinner');
+
+    const oldUrl = $("input[name=jiraCleanOldIssues]").val();
+    const requestData = Object.assign({}, {
+        oldUrl: oldUrl
+    });
+
     AJS.$.ajax({
-        url: createRequestPath('config/blackduck'),
+        url: createRequestPath('config/management'),
         dataType: "json",
+        type: "POST",
+        contentType: "application/json",
+        data: JSON.stringify(requestData),
+        processData: false,
         success: function (config) {
-            console.log("Successful get of hub details for " + config.hubUrl);
-
-            updateValue("hubServerUrl", config.hubUrl);
-            updateValue("hubTimeout", config.timeout);
-            updateValue("hubTrustCert", config.trustCert);
-            updateValue("bdApiToken", config.apiToken);
-            updateValue("proxyHost", config.hubProxyHost);
-            updateValue("proxyPort", config.hubProxyPort);
-            updateValue("proxyUsername", config.hubProxyUser);
-            updateValue("proxyPassword", config.hubProxyPassword);
-
-            checkProxyConfig();
-
-            handleError(errorMessageFieldId, config.errorMessage, true, true);
-            handleErrorHubDetails('hubServerUrlErrorRow', 'hubServerUrlError', config.hubUrlError);
-            handleErrorHubDetails('hubTimeoutErrorRow', 'hubTimeoutError', config.timeoutError);
-            handleErrorHubDetails('hubTrustCertErrorRow', 'hubTrustCertError', config.trustCertError);
-            handleErrorHubDetails('bdApiTokenErrorRow', 'bdApiTokenError', config.apiTokenError);
-            handleErrorHubDetails('proxyHostErrorRow', 'proxyHostError', config.hubProxyHostError);
-            handleErrorHubDetails('proxyPortErrorRow', 'proxyPortError', config.hubProxyPortError);
-            handleErrorHubDetails('proxyUsernameErrorRow', 'proxyUsernameError', config.hubProxyUserError);
-            handleErrorHubDetails('proxyPasswordErrorRow', 'proxyPasswordError', config.hubProxyPasswordError);
-
-        }, error: function (response) {
-            console.log("putConfig(): " + response.responseText);
-            alert("There was an error loading the configuration.");
-            handleDataRetrievalError(response, 'configurationError', "There was a problem retrieving the configuration.", "Configuration Error");
+            console.log("Successful issue update.");
+        },
+        error: function (response) {
+            console.log("postConfig(): " + response.responseText);
+            alert("There was an error updating issues.");
         },
         complete: function (jqXHR, textStatus) {
-            stopProgressSpinner('hubDetailsProgressSpinner');
+            stopProgressSpinner('managementProgressSpinner');
             console.log("Completed get of hub details: " + textStatus);
         }
     });

--- a/src/main/resources/templates/blackduck-jira.vm
+++ b/src/main/resources/templates/blackduck-jira.vm
@@ -32,6 +32,9 @@
             <li class="menu-item">
                 <a href="#FieldMapping">Issue Fields</a>
             </li>
+            <li class="menu-item">
+                <a href="#Management">Management</a>
+            </li>
         </ul>
         <div id="PluginAccess" class="tabs-pane active-pane">
             #parse("/templates/jira-access.vm")
@@ -46,6 +49,10 @@
 
         <div id="FieldMapping" class="tabs-pane">
             #parse("/templates/field-mapping.vm")
+        </div>
+
+        <div id="Management" class="tabs-pane">
+            #parse("/templates/management.vm")
         </div>
 
         <fieldset class="errorSection hidden" id="ticketCreationFieldSet">

--- a/src/main/resources/templates/management.vm
+++ b/src/main/resources/templates/management.vm
@@ -1,0 +1,28 @@
+<div id="aui-hub-message-field" class="aui-message hidden">
+    <p class="title">
+        <span id="aui-hub-message-title" class="aui-icon"></span>
+        <strong id="aui-hub-message-title-text"></strong>
+    </p>
+    <p id="aui-hub-message-text"></p>
+</div>
+
+<div id="configurationErrorRow" class="field-group hidden">
+    <label> </label>
+    <div id="configurationError" class="error"></div>
+</div>
+
+<fieldset class="fieldSection">
+    <legend class="legend"><i class="fa fa-angle-down" onclick="toggleDisplay(this,'managementArea');"> </i>Management</legend>
+    <div id="managementArea">
+        <div class="blackduck-details-field-group">
+            <label class="blackDuckDetailsLabel" for="jiraCleanOldIssues">Old BlackDuck server URL</label>
+            <input type="text" id="jiraCleanOldIssues" name="jiraCleanOldIssues" />
+            <span class="fa fa-info-circle infoIcon" title="This button will remove any old issues in your Jira instance that are associated with the BlackDuck host name you pass here."></span>
+            <input id="testConnectionButton" onclick="closeOldIssues(), startProgressSpinner('managementProgressSpinner');" type="button" value="Close Old Issues"
+                   class="aui-button aui-button-primary" />
+            <div id="managementProgressSpinner" style="display: inline-block;">
+                <i class="largeIcon fa fa-spinner fa-spin fa-fw"></i>
+            </div>
+        </div>
+    </div>
+</fieldset>

--- a/src/main/resources/templates/management.vm
+++ b/src/main/resources/templates/management.vm
@@ -12,13 +12,13 @@
 </div>
 
 <fieldset class="fieldSection">
-    <legend class="legend"><i class="fa fa-angle-down" onclick="toggleDisplay(this,'managementArea');"> </i>Management</legend>
+    <legend class="legend"><i class="fa fa-angle-down" onclick="toggleDisplay(this,'managementArea');"> </i>$i18n.getText('blackduck.integration.jira.management.label')</legend>
     <div id="managementArea">
         <div class="blackduck-details-field-group">
-            <label class="blackDuckDetailsLabel" for="jiraCleanOldIssues">Old BlackDuck server URL</label>
+            <label class="blackDuckDetailsLabel" for="jiraCleanOldIssues">$i18n.getText('blackduck.integration.jira.management.clean.old.issues.label')</label>
             <input type="text" id="jiraCleanOldIssues" name="jiraCleanOldIssues" />
-            <span class="fa fa-info-circle infoIcon" title="This button will remove any old issues in your Jira instance that are associated with the BlackDuck host name you pass here."></span>
-            <input id="testConnectionButton" onclick="closeOldIssues();" type="button" value="Close Old Issues"
+            <span class="fa fa-info-circle infoIcon" title="$i18n.getText('blackduck.integration.jira.management.clean.old.issues.description')"></span>
+            <input id="testConnectionButton" onclick="closeOldIssues();" type="button" value="$i18n.getText('blackduck.integration.jira.management.clean.old.issues.button')"
                    class="aui-button aui-button-primary" />
             <div id="managementProgressSpinner" style="display: inline-block;">
                 <i></i>

--- a/src/main/resources/templates/management.vm
+++ b/src/main/resources/templates/management.vm
@@ -18,10 +18,10 @@
             <label class="blackDuckDetailsLabel" for="jiraCleanOldIssues">Old BlackDuck server URL</label>
             <input type="text" id="jiraCleanOldIssues" name="jiraCleanOldIssues" />
             <span class="fa fa-info-circle infoIcon" title="This button will remove any old issues in your Jira instance that are associated with the BlackDuck host name you pass here."></span>
-            <input id="testConnectionButton" onclick="closeOldIssues(), startProgressSpinner('managementProgressSpinner');" type="button" value="Close Old Issues"
+            <input id="testConnectionButton" onclick="closeOldIssues();" type="button" value="Close Old Issues"
                    class="aui-button aui-button-primary" />
             <div id="managementProgressSpinner" style="display: inline-block;">
-                <i class="largeIcon fa fa-spinner fa-spin fa-fw"></i>
+                <i></i>
             </div>
         </div>
     </div>


### PR DESCRIPTION
I did something a little bad and added my own code for functionality we already have elsewhere. But since it's so hard to get those objects, this way was far easier. This should be fixed in our rework.

Added a feature for a new button that allows users to close issues that are still open but are associated with a different hub instance.